### PR TITLE
Add mtime check exclusion

### DIFF
--- a/cmd/fsdt/cmd/root.go
+++ b/cmd/fsdt/cmd/root.go
@@ -23,6 +23,7 @@ type options struct {
 	caseInsensitive bool
 	format string
 	excludes []string
+	noMtime bool
 }
 
 var rootOpts options
@@ -77,6 +78,10 @@ var rootCmd = &cobra.Command{
 		}
 		cfg.CaseSensitive = !rootOpts.caseInsensitive
 		cfg.ExcludeGlobs = append([]string(nil), rootOpts.excludes...)
+		// Apply mtime exclusion if requested (only disables, never enables)
+		if rootOpts.noMtime {
+			cfg.CompareMTime = false
+		}
 
 		// Precompute
 		if rootOpts.precompute && store != nil && (cfg.Strategy == fsdt.ChecksumPrefer || cfg.Strategy == fsdt.ChecksumEnsure) {
@@ -116,6 +121,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&rootOpts.caseInsensitive, "ci", false, "case-insensitive diff")
 	rootCmd.Flags().StringVar(&rootOpts.format, "format", "pretty", "output format: pretty|tree|json|paths")
 	rootCmd.Flags().StringArrayVar(&rootOpts.excludes, "exclude", nil, "exclude glob (repeatable), supports doublestar patterns")
+	rootCmd.Flags().BoolVar(&rootOpts.noMtime, "no-mtime", false, "exclude mtime from comparison")
 }
 
 func Execute() {

--- a/config.go
+++ b/config.go
@@ -42,6 +42,12 @@ func DefaultAccurate() Config {
 	}
 }
 
+func DefaultAccurateNoMTime() Config {
+	cfg := DefaultAccurate()
+	cfg.CompareMTime = false
+	return cfg
+}
+
 func Checksums(algo string, store ChecksumStore) Config {
 	return Config{
 		CaseSensitive: true,


### PR DESCRIPTION
Add `--no-mtime` CLI flag and `DefaultAccurateNoMTime()` library helper to exclude mtime from file comparisons.

---
<a href="https://cursor.com/background-agent?bcId=bc-10399c29-fcbe-48cd-94c1-549c12214681">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10399c29-fcbe-48cd-94c1-549c12214681">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

