### PR TITLE
Expand fsdt for tar archive operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Fast, configurable filesystem diffing for Go.
 - **Checksum stores**: xattr or sidecar cache
 - **Globs**: doublestar excludes
 - **Pretty/JSON/paths** output
+- **Tar support**: load from `.tar`, `.tar.gz`/`.tgz` and write tar/tgz from in-memory trees
 
 ### Install
 - CLI: `go install github.com/stefanpenner/go-fsdt/cmd/fsdt@latest`
@@ -23,10 +24,13 @@ Fast, configurable filesystem diffing for Go.
   - `--xattr` key (e.g. `user.sha256` on Linux, `com.yourorg.sha256` on macOS)
   - `--sidecar` DIR (alias: `--checksum-cache-dir`), `--root` PATH, `--precompute`
   - `--ci` case-insensitive, `--exclude` GLOB (repeat), `--format` pretty|tree|json|paths
+- Tar inputs:
+  - You can pass `.tar`, `.tar.gz`, or `.tgz` paths as either side. They are loaded as virtual folders.
 
 Example:
 ```bash
 fsdt --mode accurate --format tree --exclude "**/.git/**" ./left ./right
+fsdt --mode accurate left.tar.gz right/
 ```
 
 ### Library (tiny example)
@@ -36,13 +40,17 @@ import (
   op "github.com/stefanpenner/go-fsdt/operation"
 )
 
-a := fsdt.NewFolder()
-b := fsdt.NewFolder()
-a.FileString("README.md", "hello\n")
+// Build a tree
+root := fsdt.FS(map[string]string{"README.md": "hello\n"})
+// Write to tar.gz
+_ = root.WriteToTarFile("out.tgz")
+
+// Load from tar.gz
+loaded, _ := fsdt.ReadFromTarFile("out.tgz")
 
 cfg := fsdt.DefaultAccurate()
-d := fsdt.DiffWithConfig(a, b, cfg)
-_ = op.Print(d) // pretty string
+d := fsdt.DiffWithConfig(root, loaded, cfg)
+_ = op.Print(d)
 ```
 
 ### Contributing

--- a/cmd/fsdt/cmd/root.go
+++ b/cmd/fsdt/cmd/root.go
@@ -184,7 +184,13 @@ func loadPathAsFolder(path string, load fsdt.LoadOptions) (*fsdt.Folder, error) 
 	// If the path appears to be a tar archive, load via tar
 	lower := strings.ToLower(path)
 	if strings.HasSuffix(lower, ".tar") || strings.HasSuffix(lower, ".tar.gz") || strings.HasSuffix(lower, ".tgz") {
-		return fsdt.ReadFromTarFile(path)
+		// derive checksums during untar iff we are in checksum modes and algo is set
+		opts := fsdt.TarReadOptions{}
+		if load.ChecksumAlgorithm != "" {
+			opts.ComputeFileChecksum = true
+			opts.ChecksumAlgorithm = load.ChecksumAlgorithm
+		}
+		return fsdt.ReadFromTarFileWithOptions(path, opts)
 	}
 
 	info, err := os.Stat(path)

--- a/cmd/fsdt/cmd/root.go
+++ b/cmd/fsdt/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -180,6 +181,12 @@ func collectPaths(d op.Operation) []string {
 }
 
 func loadPathAsFolder(path string, load fsdt.LoadOptions) (*fsdt.Folder, error) {
+	// If the path appears to be a tar archive, load via tar
+	lower := strings.ToLower(path)
+	if strings.HasSuffix(lower, ".tar") || strings.HasSuffix(lower, ".tar.gz") || strings.HasSuffix(lower, ".tgz") {
+		return fsdt.ReadFromTarFile(path)
+	}
+
 	info, err := os.Stat(path)
 	if err != nil { return nil, err }
 	if info.IsDir() {

--- a/tar.go
+++ b/tar.go
@@ -1,0 +1,173 @@
+package fsdt
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// ReadFromTarReader constructs a Folder from a tar stream (optionally gzip-compressed if caller wraps r).
+func ReadFromTarReader(r io.Reader) (*Folder, error) {
+	tr := tar.NewReader(r)
+	root := NewFolder()
+
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		name := path.Clean(hdr.Name)
+		if name == "." || name == "" {
+			continue
+		}
+
+		// Split path using forward slashes (tar format standard)
+		components := strings.Split(name, "/")
+		parent := ensureFolder(root, components[:len(components)-1])
+		base := components[len(components)-1]
+
+		mode := os.FileMode(hdr.Mode)
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			// Explicit directory entry
+			folder := parent.Folder(base)
+			if mode != 0 { folder.mode = (mode | os.ModeDir) }
+		case tar.TypeSymlink:
+			parent.Symlink(base, hdr.Linkname)
+		case tar.TypeReg, tar.TypeRegA:
+			// Read file content
+			var buf []byte
+			if hdr.Size > 0 {
+				buf = make([]byte, hdr.Size)
+				if _, err := io.ReadFull(tr, buf); err != nil {
+					return nil, err
+				}
+			}
+			file := parent.File(base, FileOptions{Content: buf, Mode: mode, MTime: hdr.ModTime, Size: hdr.Size})
+			_ = file // silence linters if not using fields immediately
+		case tar.TypeLink:
+			// Hard links are not supported in fsdt
+			return nil, errors.New("tar: hard links not supported")
+		default:
+			// Skip other types (fifo, char, block, etc.)
+			continue
+		}
+	}
+	return root, nil
+}
+
+// ReadFromTarFile opens a .tar or .tar.gz file and returns a Folder.
+func ReadFromTarFile(path string) (*Folder, error) {
+	f, err := os.Open(path)
+	if err != nil { return nil, err }
+	defer f.Close()
+
+	if isGzipTar(path) {
+		gzr, err := gzip.NewReader(f)
+		if err != nil { return nil, err }
+		defer gzr.Close()
+		return ReadFromTarReader(gzr)
+	}
+	return ReadFromTarReader(f)
+}
+
+// WriteTarTo writes the Folder contents into a tar stream.
+func (f *Folder) WriteTarTo(w io.Writer) error {
+			tw := tar.NewWriter(w)
+			defer tw.Close()
+			return writeFolderToTar(tw, f, "")
+}
+
+// WriteToTarFile writes a .tar or .tar.gz depending on the file extension.
+func (f *Folder) WriteToTarFile(p string) error {
+	file, err := os.Create(p)
+	if err != nil { return err }
+	defer file.Close()
+
+	if isGzipTar(p) {
+		gz := gzip.NewWriter(file)
+		defer gz.Close()
+		return f.WriteTarTo(gz)
+	}
+	return f.WriteTarTo(file)
+}
+
+func writeFolderToTar(tw *tar.Writer, folder *Folder, prefix string) error {
+	// Ensure directory header for non-root folders to preserve modes
+	if prefix != "" {
+		hdr := &tar.Header{
+			Name:     toTarPath(prefix) + "/",
+			Typeflag: tar.TypeDir,
+			Mode:     int64(folder.mode.Perm()),
+		}
+		if err := tw.WriteHeader(hdr); err != nil { return err }
+	}
+	for _, name := range folder.Entries() {
+		entry := folder.Get(name)
+		full := name
+		if prefix != "" { full = prefix + "/" + name }
+		switch e := entry.(type) {
+		case *Folder:
+			if err := writeFolderToTar(tw, e, full); err != nil { return err }
+		case *File:
+			hdr := &tar.Header{
+				Name:     toTarPath(full),
+				Typeflag: tar.TypeReg,
+				Mode:     int64(e.mode.Perm()),
+				Size:     int64(len(e.content)),
+				ModTime:  e.mtime,
+			}
+			if err := tw.WriteHeader(hdr); err != nil { return err }
+			if len(e.content) > 0 {
+				if _, err := tw.Write(e.content); err != nil { return err }
+			}
+		case *Link:
+			hdr := &tar.Header{
+				Name:     toTarPath(full),
+				Typeflag: tar.TypeSymlink,
+				Linkname: e.Target(),
+				Mode:     0777,
+			}
+			if err := tw.WriteHeader(hdr); err != nil { return err }
+		default:
+			return errors.New("unexpected entry type while writing tar")
+		}
+	}
+	return nil
+}
+
+func ensureFolder(root *Folder, components []string) *Folder {
+	cur := root
+	for _, part := range components {
+		if part == "" { continue }
+		// Ensure child exists and is a folder
+		child, ok := cur._entries[part]
+		if !ok {
+			child = NewFolder()
+			cur._entries[part] = child
+		}
+		fchild, isFolder := child.(*Folder)
+		if !isFolder {
+			// Replace non-folder with folder (last write wins in tar ordering)
+			fchild = NewFolder()
+			cur._entries[part] = fchild
+		}
+		cur = fchild
+	}
+	return cur
+}
+
+func isGzipTar(p string) bool {
+	lower := strings.ToLower(p)
+	return strings.HasSuffix(lower, ".tar.gz") || strings.HasSuffix(lower, ".tgz")
+}
+
+func toTarPath(p string) string { return strings.ReplaceAll(filepath.ToSlash(p), "\\", "/") }


### PR DESCRIPTION
Add tar archive read/write support to fsdt to enable operating on tar files as sources or destinations.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3661c71-fb63-4e00-afa4-7f7c49428989">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d3661c71-fb63-4e00-afa4-7f7c49428989">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

